### PR TITLE
Use GRADLE_OPTS in environment variable

### DIFF
--- a/bin/gng
+++ b/bin/gng
@@ -122,7 +122,7 @@ gradle() {
   (
     # Restore shell options
     eval "${SAVED_OPTS}"
-    GRADLE_OPTS=$(cfg_get GRADLE_OPTS)
+    GRADLE_OPTS="$(cfg_get GRADLE_OPTS) ${GRADLE_OPTS:-}"
     export GRADLE_OPTS
     exec "${gradle}" "$@"
   )


### PR DESCRIPTION
Commit 5af1f14 results in the GRADLE_OPTS environment variable being ignored.

Fixes https://github.com/gdubw/gng/issues/19