### PR TITLE
Don't export SHELLOPTS

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -6,7 +6,6 @@ DEBUG="${DEBUG:-0}"
 if [[ "${DEBUG}" == 1 ]]; then
   set -x
 fi
-export SHELLOPTS
 
 readonly INFO_COLOR='\033[1;96m'
 readonly NO_COLOR='\033[0m' # No Color


### PR DESCRIPTION
Exporting SHELLOPTS has the potential to break any shell script invoked
by gradle, since any shell script that invokes `set -e` will have
that setting exported to _all_ shell scripts invoked as
descendant processes, changing behaviour (and in my case,
breaking the build).