### PR TITLE
Prefer python3 command

### DIFF
--- a/bin/gng
+++ b/bin/gng
@@ -141,14 +141,14 @@ bootstrap_help() {
 }
 
 function parse_gradle_version() {
-    if command -v python &> /dev/null
-    then
-        python -c "import json,sys; obj=json.load(sys.stdin); print obj['version'];"
-        return
-    fi
     if command -v python3 &> /dev/null
     then
         python3 -c "import json,sys; obj=json.load(sys.stdin); print (obj['version']);"
+        return
+    fi
+    if command -v python &> /dev/null
+    then
+        python -c "import json,sys; obj=json.load(sys.stdin); print obj['version'];"
         return
     fi
     die "Cannot find python/python3 interpreter !"


### PR DESCRIPTION
If version-less symlinks are present on the system (required for scripts with `#!/usr/bin/env python` for instance) assuming that `python` is Python 2 will fail. This prefers `python3` before falling back to `python`.