### PR TITLE
Do not require gradlew execution permission

### DIFF
--- a/bin/gng
+++ b/bin/gng
@@ -124,7 +124,7 @@ gradle() {
     eval "${SAVED_OPTS}"
     GRADLE_OPTS="$(cfg_get GRADLE_OPTS) ${GRADLE_OPTS:-}"
     export GRADLE_OPTS
-    exec "${gradle}" "$@"
+    exec "sh" "${gradle}" "$@"
   )
 }
 


### PR DESCRIPTION
Execute gradlew using shell, not directly as executable, it allows run it even if gradlew doesn't have execution permission

fixes #29